### PR TITLE
Update OpenCode to version 0.1.152

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
           # Import the OpenCode package definition
           opencode = import ./package.nix {
             inherit pkgs system;
-            version = "0.1.143";
+            version = "0.1.152";
           };
 
           # Script to verify opencode --version works

--- a/package.nix
+++ b/package.nix
@@ -50,11 +50,11 @@ let
 
   # Define the hashes for each platform package
   packageHashes = {
-    "opencode-ai" = "sha256-2dHN+e5YdnK3NY4R3frR9AOVvBw8ZsISke7oNgtMzEw="; # opencode-ai-0.1.117.tgz
-    "opencode-darwin-arm64" = "sha256-FQ+IvUs/XuV+Y9PtM6aUH3xwRJVP6ly4MH9ul1msOf8="; # opencode-darwin-arm64-0.1.117.tgz
-    "opencode-darwin-x64" = "sha256-txtoJBgHiX+sqMwf32fpqjya3Dsb28oHpmn8a61W4Mw="; # opencode-darwin-x64-0.1.117.tgz
-    "opencode-linux-arm64" = "sha256-zGWOvCkq6HDwYeivnF67ZPbg+tfZo6czfN8R8iiSEJM="; # opencode-linux-arm64-0.1.117.tgz
-    "opencode-linux-x64" = "sha256-IpB7ViZ8Wi0VMMnW+8K8G4FZQtRgCp61mqvuRIkPwto="; # opencode-linux-x64-0.1.117.tgz
+    "opencode-ai" = "sha256-x9FBGwHLnU79Pf5G2aw5uq+M5sJugw+RfuFe74dRJq4="; # opencode-ai-0.1.117.tgz
+    "opencode-darwin-arm64" = "sha256-9M+Ai1QtnTvBGfjfCVhhKvXD59Kb4SgYNrh1BQxEqP8="; # opencode-darwin-arm64-0.1.117.tgz
+    "opencode-darwin-x64" = "sha256-tOvpNnn53DJFGnZlHLnMiYb46BFfNIMCXJFNMJ1dmpA="; # opencode-darwin-x64-0.1.117.tgz
+    "opencode-linux-arm64" = "sha256-kYbme+4toFW4JqdLjrj1Xv79JD9OB1MVrfulKI+rYIM="; # opencode-linux-arm64-0.1.117.tgz
+    "opencode-linux-x64" = "sha256-u6n9yrebHpisbUJmNFwzYEHTSPCoRrFnlSW/TB6U09Q="; # opencode-linux-x64-0.1.117.tgz
   };
 
 in


### PR DESCRIPTION
This PR updates the OpenCode flake to version 0.1.152.

Changes were automatically applied by the update-opencode workflow.