### PR TITLE
Fix dynamic linking issues for NixOS

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -80,6 +80,20 @@ pkgs.stdenv.mkDerivation {
   # Dependencies
   nativeBuildInputs = with pkgs; [
     makeWrapper
+  ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = with pkgs; [
+    stdenv.cc.cc.lib
+  ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+    glibc
+    zlib
+    openssl
+    libgcc
+  ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.SystemConfiguration
   ];
 
   # Environment variables
@@ -112,6 +126,15 @@ pkgs.stdenv.mkDerivation {
     # Create wrapper script
     wrapProgram $out/bin/opencode \
       --set OPENCODE_BIN_PATH $out/lib/node_modules/${platformPackageName}/bin/opencode
+  '';
+
+  # Post-installation fixes for dynamic linking
+  postFixup = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+    # autoPatchelfHook should handle the ELF patching automatically
+    # but we can add additional fixes here if needed
+    
+    # Ensure the actual binary (not just the symlink) is executable
+    chmod +x $out/lib/node_modules/${platformPackageName}/bin/opencode
   '';
 
   meta = with pkgs.lib; {


### PR DESCRIPTION
This PR fixes the dynamic linking issues that prevented opencode from running on NixOS systems.

## Changes

- Added `autoPatchelfHook` for Linux systems to handle ELF binary patching
- Added `buildInputs` with essential system libraries (glibc, zlib, openssl, libgcc)
- Added macOS frameworks (Security, SystemConfiguration) for Darwin compatibility
- Added `postFixup` phase for additional binary patching if needed

## Technical Details

The issue was that NixOS doesn't provide standard Linux dynamic linker paths that pre-built binaries expect. The `autoPatchelfHook` automatically patches ELF binaries to use the correct library paths from the Nix store.

## Testing

This should resolve the "Could not start dynamically linked executable" error on NixOS while maintaining full macOS compatibility.

Closes #14

Generated with [Claude Code](https://claude.ai/code)