### PR TITLE
fix opencode 0.11.1 hash

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NE24parzEawK66AFhqQbKCM3Y4uSxAjHIOpnnAcL6ec=";
+    hash = "sha256-a3NReKk6wZre5GXmNRuBLzM0MtkAmIGe4r+zcZH+G1A=";
   };
 
   tui = buildGoModule {


### PR DESCRIPTION
Looks like the opencode package hash has changed since this flake was updated. Here is the correct one.